### PR TITLE
fix: call to mapping invoke should set content as an object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@ava/typescript": "^4.0.0",
+        "@aws-sdk/types": "3.329.0",
         "@aws-sdk/util-stream-node": "3.329.0",
         "@stedi/integrations-sdk": "0.1.18",
         "@stedi/sdk-client-as2": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "devDependencies": {
     "@ava/typescript": "^4.0.0",
+    "@aws-sdk/types": "3.329.0",
     "@aws-sdk/util-stream-node": "3.329.0",
     "@stedi/integrations-sdk": "0.1.18",
     "@stedi/sdk-client-as2": "0.3.4",

--- a/src/functions/transaction-to-webhook/test/handler.unit.ts
+++ b/src/functions/transaction-to-webhook/test/handler.unit.ts
@@ -148,7 +148,7 @@ test.serial(
     mappings
       .on(MapDocumentCommand, {
         id: "mapping-id",
-        content: JSON.stringify(sampleEDIAsJSON),
+        content: sampleEDIAsJSON,
       })
       .resolvesOnce({
         content: mockMappingResult,


### PR DESCRIPTION
mapping API requires the content parameter to be an object, not a json string.