### PR TITLE
feat: initial `multi-transaction-to-webhook` implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ava/typescript": "^4.0.0",
         "@smithy/types": "1.2.0",
         "@smithy/util-stream-node": "2.0.3",
-        "@stedi/integrations-sdk": "0.1.23",
+        "@stedi/integrations-sdk": "0.1.26",
         "@stedi/sdk-client-as2": "0.4.23",
         "@stedi/sdk-client-buckets": "0.4.23",
         "@stedi/sdk-client-edi-translate": "0.4.23",
@@ -1949,18 +1949,18 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-      "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -1982,9 +1982,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-      "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
+      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -1992,9 +1992,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -2141,12 +2141,12 @@
       "dev": true
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.3.tgz",
-      "integrity": "sha512-LbQ4fdsVuQC3/18Z/uia5wnk9fk8ikfHl3laYCEGhboEMJ/6oVk3zhydqljMxBCftHGUv7yUrTnZ6EAQhOf+PA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.5.tgz",
+      "integrity": "sha512-byVZ2KWLMPYAZGKjRpniAzLcygJO4ruClZKdJTuB0eCB76ONFTdptBHlviHpAZXknRz7skYWPfcgO9v30A1SyA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^2.2.0",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2154,9 +2154,9 @@
       }
     },
     "node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.2.tgz",
+      "integrity": "sha512-4PS0y1VxDnELGHGgBWlDksB2LJK8TG8lcvlWxIsgR+8vROI7Ms8h1P4FQUx+ftAX2QZv5g1CJCdhdRmQKyonyw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -2492,15 +2492,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.3.tgz",
-      "integrity": "sha512-wUO78aa0VVJVz54Lr1Nw6FYnkatbvh2saHgkT8fdtNWc7I/osaPMUJnRkBmTZZ5w+BIQ1rvr9dbGyYBTlRg2+Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.5.tgz",
+      "integrity": "sha512-lZm5DZf4b3V0saUw9WTC4/du887P6cy2fUyQgQQKRRV6OseButyD5yTzeMmXE53CaXJBMBsUvvIQ0hRVxIq56w==",
       "dev": true,
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.3",
-        "@smithy/protocol-http": "^2.0.3",
-        "@smithy/querystring-builder": "^2.0.3",
-        "@smithy/types": "^2.2.0",
+        "@smithy/abort-controller": "^2.0.5",
+        "@smithy/protocol-http": "^2.0.5",
+        "@smithy/querystring-builder": "^2.0.5",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2508,9 +2508,9 @@
       }
     },
     "node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.2.tgz",
+      "integrity": "sha512-4PS0y1VxDnELGHGgBWlDksB2LJK8TG8lcvlWxIsgR+8vROI7Ms8h1P4FQUx+ftAX2QZv5g1CJCdhdRmQKyonyw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -2533,12 +2533,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.3.tgz",
-      "integrity": "sha512-yzBYloviSLOwo2RT62vBRCPtk8mc/O2RMJfynEahbX8ZnduHpKaajvx3IuGubhamIbesi7M5HBVecDehBnlb9Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.5.tgz",
+      "integrity": "sha512-d2hhHj34mA2V86doiDfrsy2fNTnUOowGaf9hKb0hIPHqvcnShU4/OSc4Uf1FwHkAdYF3cFXTrj5VGUYbEuvMdw==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^2.2.0",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2546,9 +2546,9 @@
       }
     },
     "node_modules/@smithy/protocol-http/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.2.tgz",
+      "integrity": "sha512-4PS0y1VxDnELGHGgBWlDksB2LJK8TG8lcvlWxIsgR+8vROI7Ms8h1P4FQUx+ftAX2QZv5g1CJCdhdRmQKyonyw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -2558,12 +2558,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.3.tgz",
-      "integrity": "sha512-HPSviVgGj9FT4jPdprkfSGF3nhFzpQMST1hOC1Oh6eaRB2KTQCsOZmS7U4IqGErVPafe6f/yRa1DV73B5gO50w==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.5.tgz",
+      "integrity": "sha512-4DCX9krxLzATj+HdFPC3i8pb7XTAWzzKqSw8aTZMjXjtQY+vhe4azMAqIvbb6g7JKwIkmkRAjK6EXO3YWSnJVQ==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^2.2.0",
+        "@smithy/types": "^2.2.2",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@smithy/querystring-builder/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.2.tgz",
+      "integrity": "sha512-4PS0y1VxDnELGHGgBWlDksB2LJK8TG8lcvlWxIsgR+8vROI7Ms8h1P4FQUx+ftAX2QZv5g1CJCdhdRmQKyonyw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -2887,9 +2887,9 @@
       }
     },
     "node_modules/@smithy/util-stream-node/node_modules/@smithy/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Ahpt9KvD0mWeWiyaGo5EBE7KOByLl3jl4CD9Ps/r8qySgzVzo/4qsa+vvstOU3ZEriALmrPqUKIhqHt0Rn+m6g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.2.tgz",
+      "integrity": "sha512-4PS0y1VxDnELGHGgBWlDksB2LJK8TG8lcvlWxIsgR+8vROI7Ms8h1P4FQUx+ftAX2QZv5g1CJCdhdRmQKyonyw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -3069,9 +3069,9 @@
       }
     },
     "node_modules/@stedi/integrations-sdk": {
-      "version": "0.1.23",
-      "resolved": "https://registry.npmjs.org/@stedi/integrations-sdk/-/integrations-sdk-0.1.23.tgz",
-      "integrity": "sha512-Q33pkJxsvf4LQzqPUwYCY43tMM12hhNe/ZXCybVG7QOBSmH8Mr00GS6Ka/FeG94w0KUD9Y0WIoU/3+fkWuin3Q==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@stedi/integrations-sdk/-/integrations-sdk-0.1.26.tgz",
+      "integrity": "sha512-s9yGNyBboHeSwVixuCMBoe00Elfn902FM29YvzwcuxdSqTCAWyY4F3DTD7bEy9D1yOUnuHoFMzy3LAZXyfMPMA==",
       "dev": true,
       "bin": {
         "stedi-integrations": "dist/cli.js"
@@ -4296,9 +4296,9 @@
       }
     },
     "node_modules/@stedi/sdk-client-tokens": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/@stedi/sdk-client-tokens/-/sdk-client-tokens-0.4.23.tgz",
-      "integrity": "sha512-wcU1WptzuojRHPc4G6JRo/AiTTo/4mu1AzVtCIvbph/jWYXLfaFoC+Vzw/dYqVGVKvPOaF5KGVugZF2sf/5Bzw==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@stedi/sdk-client-tokens/-/sdk-client-tokens-0.4.29.tgz",
+      "integrity": "sha512-XBboqgwzh1c2pOv0OHappW6nZyqXupGpzQCvlJM0YQwWhBiFI/bjFF5Fq7AU1Vux+avqrx95AhPOyOwHiPYKdg==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -4511,21 +4511,21 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
-      "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
+      "version": "18.17.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.12.tgz",
+      "integrity": "sha512-d6xjC9fJ/nSnfDeU0AMDsaJyb1iHsqCSOdi84w4u+SlN/UgQdY5tRhpMzaFYsI4mnpvgTivEaQd0yOUhAtOnEQ==",
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
       "dev": true
     },
     "node_modules/@types/sinon": {
-      "version": "10.0.15",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.15.tgz",
-      "integrity": "sha512-3lrFNQG0Kr2LDzvjyjB6AMJk4ge+8iYhQfdnSwIwlG88FUOV43kPcQqDZkDa/h3WSZy6i8Fr0BSjfQtB1B3xuQ==",
+      "version": "10.0.16",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.16.tgz",
+      "integrity": "sha512-j2Du5SYpXZjJVJtXBokASpPRj+e2z+VUhCPHmM6WMfe3dpHu6iVKJMU6AiBcMp/XTAYnEj6Wc1trJUWwZ0QaAQ==",
       "dev": true,
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
@@ -5093,9 +5093,9 @@
       }
     },
     "node_modules/c8": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-8.0.0.tgz",
-      "integrity": "sha512-XHA5vSfCLglAc0Xt8eLBZMv19lgiBSjnb1FLAQgnwkuhJYEonpilhEB4Ea3jPAbm0FhD6VVJrc0z73jPe7JyGQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-8.0.1.tgz",
+      "integrity": "sha512-EINpopxZNH1mETuI0DzRA4MZpAUH+IFiRhnmFD3vFr3vdrgxqi3VfE3KL0AIL+zDq8rC9bZqwM/VDmmoe04y7w==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -5103,98 +5103,19 @@
         "find-up": "^5.0.0",
         "foreground-child": "^2.0.0",
         "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-reports": "^3.1.4",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
         "rimraf": "^3.0.2",
         "test-exclude": "^6.0.0",
         "v8-to-istanbul": "^9.0.0",
-        "yargs": "^16.2.0",
-        "yargs-parser": "^20.2.9"
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
       },
       "bin": {
         "c8": "bin/c8.js"
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/c8/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/c8/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/c8/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "node_modules/c8/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/c8/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/c8/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/c8/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/call-bind": {
@@ -5211,9 +5132,9 @@
       }
     },
     "node_modules/callsites": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-4.0.0.tgz",
-      "integrity": "sha512-y3jRROutgpKdz5vzEhWM34TidDU8vkJppF8dszITeb1PQmSqV3DTxyV8G/lyO/DNvtE1YTedehmw9MPZsCBHxQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-4.1.0.tgz",
+      "integrity": "sha512-aBMbD1Xxay75ViYezwT40aQONfr+pSXTHwNKvIXhXD6+LY3F1dLIcceoC5OZKBVHbXcysz1hL9D2w0JJIMXpUw==",
       "dev": true,
       "engines": {
         "node": ">=12.20"
@@ -5641,16 +5562,16 @@
       "dev": true
     },
     "node_modules/error-cause": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/error-cause/-/error-cause-1.0.5.tgz",
-      "integrity": "sha512-MTHAT/2lds0Ge2rOi4KIpAmZYc+Q2NleI8RkkidCggbQ2C7pBnhssihAZtLEbv+Ai8FahWKZbCJS4gF4tf5kPQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/error-cause/-/error-cause-1.0.6.tgz",
+      "integrity": "sha512-WnmxGRdAtXU/8h8wDZzCDBL4qEx+OqY4DjPpjkVoPJIyzjIdalHmL9FQKreddtbaEYjbxMIKLDIKDiu1QiRLlg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-aggregate-error": "^1.0.9",
-        "get-intrinsic": "^1.1.3",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "es-aggregate-error": "^1.0.10",
+        "get-intrinsic": "^1.2.1",
         "globalthis": "^1.0.3",
         "has-property-descriptors": "^1.0.0"
       },
@@ -5712,16 +5633,16 @@
       }
     },
     "node_modules/es-aggregate-error": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.9.tgz",
-      "integrity": "sha512-fvnX40sb538wdU6r4s35cq4EY6Lr09Upj40BEVem4LEsuW8XgQep9yD5Q1U2KftokNp1rWODFJ2qwZSsAjFpbg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.10.tgz",
+      "integrity": "sha512-qX3K9eP7HcgeFckzRy1T5Mtb7wYwZt9ahFteBDigG5Te0vGOmOH3dHDncBiuNkZBX9i+C8LgSbpqSEl97gN11Q==",
       "dev": true,
       "dependencies": {
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "function-bind": "^1.1.1",
         "functions-have-names": "^1.2.3",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.1",
         "globalthis": "^1.0.3",
         "has-property-descriptors": "^1.0.0"
       },
@@ -5785,28 +5706,28 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
-      "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
+      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.1.0",
-        "@eslint/js": "8.44.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "8.48.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.6.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -5840,9 +5761,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -5886,9 +5807,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5954,9 +5875,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.1.tgz",
-      "integrity": "sha512-CvefSOsDdaYYvxChovdrPo/ZGt8d5lrJWleAc1diXRKhHGiTYEI26cvo8Kle/wGnsizoCJjK73FMg1/IkIwiNA==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -6100,9 +6021,9 @@
       }
     },
     "node_modules/execa": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
-      "integrity": "sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -6136,9 +6057,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -6254,17 +6175,18 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+      "integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.7",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/flatted": {
@@ -6303,9 +6225,9 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -6323,15 +6245,15 @@
       "dev": true
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "functions-have-names": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6434,9 +6356,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -7005,23 +6927,23 @@
       }
     },
     "node_modules/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^3.0.0",
+        "make-dir": "^4.0.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
-      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -7053,6 +6975,13 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -7078,6 +7007,16 @@
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
       "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
       "dev": true
+    },
+    "node_modules/keyv": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -7152,27 +7091,18 @@
       }
     },
     "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "dependencies": {
-        "semver": "^6.0.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/make-error": {
@@ -7764,9 +7694,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -8408,9 +8338,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -8535,9 +8465,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8563,9 +8493,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+      "integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
       "dev": true,
       "dependencies": {
         "busboy": "^1.6.0"
@@ -8613,29 +8543,14 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/v8-to-istanbul/node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/v8-to-istanbul/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
-    },
     "node_modules/v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
+      "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/well-known-symbols": {
@@ -8799,9 +8714,9 @@
       }
     },
     "node_modules/write-file-atomic/node_modules/signal-exit": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -8844,12 +8759,12 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs/node_modules/ansi-regex": {
@@ -8902,15 +8817,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -8933,9 +8839,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
+      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@ava/typescript": "^4.0.0",
     "@smithy/types": "1.2.0",
     "@smithy/util-stream-node": "2.0.3",
-    "@stedi/integrations-sdk": "0.1.23",
+    "@stedi/integrations-sdk": "0.1.26",
     "@stedi/sdk-client-as2": "0.4.23",
     "@stedi/sdk-client-buckets": "0.4.23",
     "@stedi/sdk-client-edi-translate": "0.4.23",

--- a/src/functions/event-to-webhook/test/handler.unit.ts
+++ b/src/functions/event-to-webhook/test/handler.unit.ts
@@ -5,7 +5,7 @@ import { mock } from "node:test";
 
 const event = sampleTransactionProcessedEvent();
 
-test.afterEach(() => mock.reset());
+test.afterEach.always(() => mock.reset());
 
 const authHeaderIfEnvVarSet = () => process.env.AUTHORIZATION
   ? { "Authorization": process.env.AUTHORIZATION }

--- a/src/functions/generate-edi/test/handler.unit.ts
+++ b/src/functions/generate-edi/test/handler.unit.ts
@@ -9,7 +9,7 @@ import { ZodError } from "zod";
 const mappings = mockClient(MappingsClient);
 const partners = mockClient(PartnersClient);
 
-test.afterEach(() => {
+test.afterEach.always(() => {
   mappings.reset();
   partners.reset();
 });

--- a/src/functions/multi-transaction-to-webhook/handler.ts
+++ b/src/functions/multi-transaction-to-webhook/handler.ts
@@ -98,22 +98,18 @@ export const handler = async (event: CoreTransactionProcessedV2Event) => {
 const extractOutputArtifactUrl = (
   event: CoreTransactionProcessedV2Event,
 ): string => {
-  const filteredOutputArtifacts = event.detail.artifacts.filter(
+  const [outputArtifact, ...unexpectedMatches] = event.detail.artifacts.filter(
     (artifact) => artifact.usage === "output",
   );
 
-  if (filteredOutputArtifacts.length !== 1) {
+  if (!outputArtifact || unexpectedMatches.length > 0) {
+    const actualCount = unexpectedMatches.length + (outputArtifact ? 1 : 0);
     throw new Error(
-      `Expected exactly 1 output artifact in event, received ${filteredOutputArtifacts.length}`,
+      `Expected exactly 1 output artifact in event, received ${actualCount}`,
     );
   }
 
-  const outputArtifactUrl = filteredOutputArtifacts[0]?.url;
-  if (!outputArtifactUrl) {
-    throw new Error("Unable to extract output artifact url from event");
-  }
-
-  return outputArtifactUrl;
+  return outputArtifact.url;
 };
 
 const loadDestinationConfig = async (

--- a/src/functions/multi-transaction-to-webhook/handler.ts
+++ b/src/functions/multi-transaction-to-webhook/handler.ts
@@ -1,0 +1,119 @@
+import z from "zod";
+import { type CoreTransactionProcessedEvent } from "@stedi/integrations-sdk";
+import { bucketsClient, mappingsClient, stashClient } from "@stedi/integrations-sdk/clients";
+import { GetObjectCommand } from "@stedi/sdk-client-buckets";
+import { MapDocumentCommand } from "@stedi/sdk-client-mappings";
+import { DocumentType } from "@aws-sdk/types";
+import { GetValueCommand } from "@stedi/sdk-client-stash";
+
+const STASH_KEYSPACE_NAME= "destinations-configuration";
+
+const DestinationConfigSchema = z.strictObject({
+  webhookUrl: z.string(),
+  mappingId: z.string().optional(),
+  authorization: z.string().optional(),
+});
+
+type DestinationConfig = z.infer<typeof DestinationConfigSchema>;
+
+export const handler = async (event: CoreTransactionProcessedEvent) => {
+  // get bucket reference for the JSON version of EDI Transaction Set
+  const {
+    detail: { output },
+  } = event;
+
+  // retrieve the file contents using bucket reference
+  const client = bucketsClient();
+  const getFile = await client.send(
+    new GetObjectCommand({ bucketName: output.bucketName, key: output.key })
+  );
+
+  if (getFile.body === undefined) {
+    throw new Error("Failed to retrieve file from Bucket");
+  }
+
+  const bodyString = await getFile.body.transformToString();
+  let body: unknown;
+  try {
+    body = JSON.parse(bodyString);
+  } catch (e) {
+    throw new Error("File is not a JSON file");
+  }
+
+  const destinationConfig = await loadDestinationConfig(
+    event.detail.partnership.partnershipId,
+    event.detail.transaction.transactionSetIdentifier
+  );
+
+  const webhookPayload =
+    destinationConfig.mappingId === undefined
+      ? bodyString
+      : await invokeMapping(destinationConfig.mappingId, body);
+
+  // send JSON to endpoint
+  const result = await fetch(destinationConfig.webhookUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(destinationConfig.authorization && {
+        Authorization: destinationConfig.authorization,
+      }),
+    },
+    body: webhookPayload,
+  });
+
+  if (!result.ok) {
+    throw new Error(
+      `delivery to ${destinationConfig.webhookUrl} failed: ${result.statusText} (status code: ${result.status})`
+    );
+  }
+
+  return { ok: result.ok, statusCode: result.status };
+};
+
+const loadDestinationConfig = async (
+  partnershipId: string,
+  transactionSettingId: string,
+): Promise<DestinationConfig> => {
+  // first look for configuration specific to transaction set and partnership
+  const stashValueForPartnership = (await stashClient().send(new GetValueCommand({
+    keyspaceName: STASH_KEYSPACE_NAME,
+    key: `inbound|${transactionSettingId}|${partnershipId}`,
+  }))).value;
+
+  // if not found, look for configuration specific to transaction set
+  const stashValue = stashValueForPartnership
+    || (await stashClient().send(new GetValueCommand({
+      keyspaceName: STASH_KEYSPACE_NAME,
+      key: `inbound|${transactionSettingId}`,
+    }))).value;
+
+  const parsedValue = DestinationConfigSchema.safeParse(stashValue);
+  if (!parsedValue.success) {
+    throw new Error(
+      `Invalid stash configuration for inbound transaction. partnershipId=${partnershipId}, transactionSet: ${transactionSettingId}`
+    );
+  }
+
+  return parsedValue.data;
+};
+
+const invokeMapping = async (
+  mappingId: string,
+  input: unknown
+): Promise<string> => {
+  const mappingResult = await mappingsClient().send(
+    new MapDocumentCommand({
+      id: mappingId,
+      content: input as DocumentType,
+    })
+  );
+
+  if (!mappingResult.content) {
+    throw new Error(
+      `map (id=${mappingId}) operation did not return any content`
+    );
+  }
+
+  return JSON.stringify(mappingResult.content);
+};

--- a/src/functions/multi-transaction-to-webhook/handler.ts
+++ b/src/functions/multi-transaction-to-webhook/handler.ts
@@ -1,74 +1,119 @@
-import z from "zod";
-import { type CoreTransactionProcessedEvent } from "@stedi/integrations-sdk";
-import { bucketsClient, mappingsClient, stashClient } from "@stedi/integrations-sdk/clients";
-import { GetObjectCommand } from "@stedi/sdk-client-buckets";
-import { MapDocumentCommand } from "@stedi/sdk-client-mappings";
+import { type CoreTransactionProcessedV2Event } from "@stedi/integrations-sdk";
+import { mappingsClient, stashClient } from "@stedi/integrations-sdk/clients";
+import {
+  MapDocumentCommand,
+  MapDocumentCommandOutput,
+  MappingFailedException,
+} from "@stedi/sdk-client-mappings";
 import { DocumentType } from "@aws-sdk/types";
 import { GetValueCommand } from "@stedi/sdk-client-stash";
+import { resolveToken } from "@stedi/sdk-token-provider-aws-identity";
+import {
+  DestinationConfig,
+  DestinationConfigSchema,
+} from "./schema/DestinationConfig.js";
 
-const STASH_KEYSPACE_NAME= "destinations-configuration";
+const STASH_KEYSPACE_NAME = "destinations-configuration";
 
-const DestinationConfigSchema = z.strictObject({
-  webhookUrl: z.string(),
-  mappingId: z.string().optional(),
-  authorization: z.string().optional(),
-});
+export const getAuthToken = async () => await resolveToken();
 
-type DestinationConfig = z.infer<typeof DestinationConfigSchema>;
+export const handler = async (event: CoreTransactionProcessedV2Event) => {
+  // get artifact url for the JSON version of EDI Transaction Set
+  const outputArtifactUrl = extractOutputArtifactUrl(event);
 
-export const handler = async (event: CoreTransactionProcessedEvent) => {
-  // get bucket reference for the JSON version of EDI Transaction Set
-  const {
-    detail: { output },
-  } = event;
+  // get auth token to use when fetching output artifact
+  const { token } = await getAuthToken();
 
-  // retrieve the file contents using bucket reference
-  const client = bucketsClient();
-  const getFile = await client.send(
-    new GetObjectCommand({ bucketName: output.bucketName, key: output.key })
-  );
-
-  if (getFile.body === undefined) {
-    throw new Error("Failed to retrieve file from Bucket");
-  }
-
-  const bodyString = await getFile.body.transformToString();
-  let body: unknown;
-  try {
-    body = JSON.parse(bodyString);
-  } catch (e) {
-    throw new Error("File is not a JSON file");
-  }
-
-  const destinationConfig = await loadDestinationConfig(
-    event.detail.partnership.partnershipId,
-    event.detail.transaction.transactionSetIdentifier
-  );
-
-  const webhookPayload =
-    destinationConfig.mappingId === undefined
-      ? bodyString
-      : await invokeMapping(destinationConfig.mappingId, body);
-
-  // send JSON to endpoint
-  const result = await fetch(destinationConfig.webhookUrl, {
-    method: "POST",
+  // fetch output artifact
+  const outputArtifactFetchResult = await fetch(outputArtifactUrl, {
+    method: "GET",
     headers: {
-      "Content-Type": "application/json",
-      ...(destinationConfig.authorization && {
-        Authorization: destinationConfig.authorization,
-      }),
+      Authorization: `Bearer ${token}`,
     },
-    body: webhookPayload,
   });
 
-  if (!result.ok) {
+  if (!outputArtifactFetchResult.ok) {
+    const artifactResponseSummary = {
+      statusText: outputArtifactFetchResult.statusText,
+      statusCode: outputArtifactFetchResult.status,
+      responseText: await outputArtifactFetchResult.text(),
+    };
+
     throw new Error(
-      `delivery to ${destinationConfig.webhookUrl} failed: ${result.statusText} (status code: ${result.status})`
+      `Failed to retrieve output artifact: ${JSON.stringify(
+        artifactResponseSummary,
+        null,
+        2,
+      )}`,
     );
   }
 
-  return { ok: result.ok, statusCode: result.status };
+  // extract artifact JSON from fetch response body
+  const body = await outputArtifactFetchResult.json();
+
+  // load destination config for transaction set / partnership
+  const destinationConfig = await loadDestinationConfig(
+    event.detail.partnership.partnershipId,
+    event.detail.x12.metadata.transaction.transactionSetIdentifier,
+  );
+
+  // prepare string payload to send to destination webhook (with mapping optionally applied)
+  const webhookPayload =
+    destinationConfig.mappingId === undefined
+      ? JSON.stringify(body)
+      : await mappingResultAsString(destinationConfig, body);
+
+  // send stringified JSON to endpoint
+  const destinationWebhookFetchResult = await fetch(
+    destinationConfig.webhookUrl,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(destinationConfig.authorization && {
+          Authorization: destinationConfig.authorization,
+        }),
+      },
+      body: webhookPayload,
+    },
+  );
+
+  const destinationWebhookResponseSummary = {
+    statusText: destinationWebhookFetchResult.statusText,
+    statusCode: destinationWebhookFetchResult.status,
+    responseText: await destinationWebhookFetchResult.text(),
+  };
+
+  if (!destinationWebhookFetchResult.ok) {
+    throw new Error(
+      `delivery to ${destinationConfig.webhookUrl} failed: ${JSON.stringify(
+        destinationWebhookResponseSummary,
+      )}`,
+    );
+  }
+
+  return destinationWebhookResponseSummary;
+};
+
+const extractOutputArtifactUrl = (
+  event: CoreTransactionProcessedV2Event,
+): string => {
+  const filteredOutputArtifacts = event.detail.artifacts.filter(
+    (artifact) => artifact.usage === "output",
+  );
+
+  if (filteredOutputArtifacts.length !== 1) {
+    throw new Error(
+      `Expected exactly 1 output artifact in event, received ${filteredOutputArtifacts.length}`,
+    );
+  }
+
+  const outputArtifactUrl = filteredOutputArtifacts[0]?.url;
+  if (!outputArtifactUrl) {
+    throw new Error("Unable to extract output artifact url from event");
+  }
+
+  return outputArtifactUrl;
 };
 
 const loadDestinationConfig = async (
@@ -76,44 +121,92 @@ const loadDestinationConfig = async (
   transactionSettingId: string,
 ): Promise<DestinationConfig> => {
   // first look for configuration specific to transaction set and partnership
-  const stashValueForPartnership = (await stashClient().send(new GetValueCommand({
-    keyspaceName: STASH_KEYSPACE_NAME,
-    key: `inbound|${transactionSettingId}|${partnershipId}`,
-  }))).value;
+  const partnershipScopedStashKey = `inbound|${transactionSettingId}|${partnershipId}`;
+  const stashValueForPartnership = (
+    await stashClient().send(
+      new GetValueCommand({
+        keyspaceName: STASH_KEYSPACE_NAME,
+        key: partnershipScopedStashKey,
+      }),
+    )
+  ).value;
 
   // if not found, look for configuration specific to transaction set
-  const stashValue = stashValueForPartnership
-    || (await stashClient().send(new GetValueCommand({
-      keyspaceName: STASH_KEYSPACE_NAME,
-      key: `inbound|${transactionSettingId}`,
-    }))).value;
+  const transactionSetScopedStashKey = `inbound|${transactionSettingId}`;
+  const stashValue =
+    stashValueForPartnership ||
+    (
+      await stashClient().send(
+        new GetValueCommand({
+          keyspaceName: STASH_KEYSPACE_NAME,
+          key: transactionSetScopedStashKey,
+        }),
+      )
+    ).value;
 
-  const parsedValue = DestinationConfigSchema.safeParse(stashValue);
-  if (!parsedValue.success) {
+  if (!stashValue) {
+    const destinationConfigHintMessage = `Add destination config to '${STASH_KEYSPACE_NAME}' stash keyspace using one of the following keys: '${partnershipScopedStashKey}' or '${transactionSetScopedStashKey}'`;
     throw new Error(
-      `Invalid stash configuration for inbound transaction. partnershipId=${partnershipId}, transactionSet: ${transactionSettingId}`
+      `No matching stash configuration found for inbound transaction: partnershipId=${partnershipId}, transactionSet=${transactionSettingId}. ${destinationConfigHintMessage}`,
     );
   }
 
-  return parsedValue.data;
+  const parseResult = DestinationConfigSchema.safeParse(stashValue);
+  if (!parseResult.success) {
+    const parseErrorDetails = `Configuration parsing errors: ${JSON.stringify(
+      parseResult.error.issues,
+    )}`;
+    throw new Error(
+      `Invalid stash configuration for inbound transaction: partnershipId=${partnershipId}, transactionSet=${transactionSettingId}. ${parseErrorDetails}`,
+    );
+  }
+
+  return parseResult.data;
 };
 
-const invokeMapping = async (
-  mappingId: string,
-  input: unknown
+const mappingResultAsString = async (
+  destinationConfig: DestinationConfig,
+  input: unknown,
 ): Promise<string> => {
-  const mappingResult = await mappingsClient().send(
-    new MapDocumentCommand({
-      id: mappingId,
-      content: input as DocumentType,
-    })
-  );
+  // optionally wrap input in `transactionSets` array to conform to guideJson
+  const mappingInput = destinationConfig.mapAsGuideJson
+    ? { transactionSets: [input] }
+    : input;
+
+  const mappingResult = await invokeMapping(destinationConfig, mappingInput);
 
   if (!mappingResult.content) {
     throw new Error(
-      `map (id=${mappingId}) operation did not return any content`
+      `map (id=${destinationConfig.mappingId}) operation did not return any content`,
     );
   }
 
   return JSON.stringify(mappingResult.content);
+};
+
+const invokeMapping = async (
+  destinationConfig: DestinationConfig,
+  input: unknown,
+): Promise<MapDocumentCommandOutput> => {
+  try {
+    return await mappingsClient().send(
+      new MapDocumentCommand({
+        id: destinationConfig.mappingId,
+        content: input as DocumentType,
+        validationMode: destinationConfig.mappingValidation,
+      }),
+    );
+  } catch (e) {
+    // If strict mode mapping fails validation, include validation errors in thrown error
+    if (e instanceof MappingFailedException && e.code === "validation_failed") {
+      const validationErrorDetails = `Validation errors: ${JSON.stringify(
+        e.validationErrors,
+      )}`;
+      throw new Error(
+        `Strict mapping validation failed: ${e.message} ${validationErrorDetails}`,
+      );
+    }
+
+    throw e;
+  }
 };

--- a/src/functions/multi-transaction-to-webhook/schema/DestinationConfig.ts
+++ b/src/functions/multi-transaction-to-webhook/schema/DestinationConfig.ts
@@ -1,0 +1,11 @@
+import z from "zod";
+
+export const DestinationConfigSchema = z.strictObject({
+  webhookUrl: z.string(),
+  authorization: z.string().optional(),
+  mappingId: z.string().optional(),
+  mapAsGuideJson: z.boolean().default(true),
+  mappingValidation: z.enum(["strict"]).optional(),
+});
+
+export type DestinationConfig = z.infer<typeof DestinationConfigSchema>;

--- a/src/functions/multi-transaction-to-webhook/schema/destination-config.json
+++ b/src/functions/multi-transaction-to-webhook/schema/destination-config.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/destination-webhook.json",
+  "type": "object",
+  "properties": {
+    "webhookUrl": {
+      "type": "string"
+    },
+    "authorization": {
+      "type": "string"
+    },
+    "mappingId": {
+      "type": "string"
+    },
+    "mapAsGuideJson": {
+      "type": "boolean",
+      "default": true
+    },
+    "mappingValidation": {
+      "type": "string",
+      "enum": ["strict"]
+    }
+  },
+  "additionalProperties": false,
+  "required": ["webhookUrl"]
+}

--- a/src/functions/multi-transaction-to-webhook/test/handler.unit.ts
+++ b/src/functions/multi-transaction-to-webhook/test/handler.unit.ts
@@ -9,7 +9,11 @@ import {
   testJwt,
 } from "@stedi/integrations-sdk/testing";
 import { mock } from "node:test";
-import { MapDocumentCommand, MappingsClient } from "@stedi/sdk-client-mappings";
+import {
+  MapDocumentCommand,
+  MappingFailedException,
+  MappingsClient,
+} from "@stedi/sdk-client-mappings";
 import { GetTokenForIAMCommand, TokensClient } from "@stedi/sdk-client-tokens";
 import { GetValueCommand, StashClient } from "@stedi/sdk-client-stash";
 
@@ -137,12 +141,14 @@ test.serial(
       custom: "payload",
     };
 
-    mappings.on(MapDocumentCommand, {
-      id: "test-mapping",
-      content: sampleEDIAsJSON,
-    }).resolvesOnce({
-      content: customMappingOutput,
-    });
+    mappings
+      .on(MapDocumentCommand, {
+        id: "test-mapping",
+        content: sampleEDIAsJSON,
+      })
+      .resolvesOnce({
+        content: customMappingOutput,
+      });
 
     mock.method(
       global,
@@ -209,5 +215,455 @@ test.serial(
       statusCode: 201,
       responseText: "result",
     });
+  },
+);
+
+test.serial(
+  "sends guide JSON output wrapped in `transactionSets` array as input to mapping by default",
+  async (t) => {
+    tokens.on(GetTokenForIAMCommand, {}).resolvesOnce({
+      id_token: testJwt,
+    });
+
+    stash
+      .on(GetValueCommand, {
+        keyspaceName: "destinations-configuration",
+        key: `inbound|${sampleTransactionSetIdentifier}|${samplePartnershipId}`,
+      })
+      .resolvesOnce({
+        value: {
+          webhookUrl: "test-webhook",
+          mappingId: "test-mapping",
+        },
+      });
+
+    const customMappingOutput = {
+      custom: "payload",
+    };
+
+    mappings
+      .on(MapDocumentCommand, {
+        id: "test-mapping",
+        content: {
+          transactionSets: [sampleEDIAsJSON],
+        },
+      })
+      .resolvesOnce({
+        content: customMappingOutput,
+      });
+
+    mock.method(
+      global,
+      // @ts-expect-error fetch is not yet present in @types/node
+      "fetch",
+      (input: RequestInfo, init: RequestInit): Promise<Response> => {
+        if (init.method === "GET") {
+          t.assert(input === sampleOutputArtifactUrl);
+          t.deepEqual(init.headers, {
+            Authorization: `Bearer ${testJwt}`,
+          });
+
+          return Promise.resolve({
+            ok: true,
+            text: async () => Promise.resolve("unused"),
+            json: async () => Promise.resolve(sampleEDIAsJSON),
+          } as Response);
+        }
+
+        t.assert(
+          init.body === JSON.stringify(customMappingOutput),
+          "JSON payload was delivered to webhook",
+        );
+        t.deepEqual(init.headers, {
+          "Content-Type": "application/json",
+          ...authHeaderIfEnvVarSet(),
+        });
+        return Promise.resolve({
+          ok: true,
+          statusText: "created",
+          status: 201,
+          text: async () => Promise.resolve("result"),
+        } as Response);
+      },
+    );
+
+    const result = await handler(event);
+
+    const { calls } =
+      (
+        // @ts-expect-error fetch is not yet present in @types/node
+        fetch as {
+          mock: { calls: { arguments: string | { method: string }[] }[] };
+        }
+      ).mock;
+    t.assert(
+      calls.length === 2,
+      "two fetch calls are made (one to retrieve artifact, one to post JSON payload to webhook)",
+    );
+    t.assert(
+      calls[0]?.arguments?.[0] === sampleOutputArtifactUrl,
+      "first fetch call retrieves output artifact",
+    );
+    t.assert(
+      calls[1]?.arguments?.[0] === "test-webhook",
+      "second fetch call posts to webhook",
+    );
+
+    const invokeMappingCalls = mappings.commandCalls(MapDocumentCommand);
+    t.assert(invokeMappingCalls.length === 1);
+
+    t.deepEqual(result, {
+      statusText: "created",
+      statusCode: 201,
+      responseText: "result",
+    });
+  },
+);
+
+test.serial(
+  "invokes mapping with strict validation when `mappingValidation` is `strict`",
+  async (t) => {
+    tokens.on(GetTokenForIAMCommand, {}).resolvesOnce({
+      id_token: testJwt,
+    });
+
+    stash
+      .on(GetValueCommand, {
+        keyspaceName: "destinations-configuration",
+        key: `inbound|${sampleTransactionSetIdentifier}|${samplePartnershipId}`,
+      })
+      .resolvesOnce({
+        value: {
+          webhookUrl: "test-webhook",
+          mappingId: "test-mapping",
+          mappingValidation: "strict",
+        },
+      });
+
+    const customMappingOutput = {
+      custom: "payload",
+    };
+
+    mappings
+      .on(MapDocumentCommand, {
+        id: "test-mapping",
+        content: {
+          transactionSets: [sampleEDIAsJSON],
+        },
+        validationMode: "strict",
+      })
+      .resolvesOnce({
+        content: customMappingOutput,
+      });
+
+    mock.method(
+      global,
+      // @ts-expect-error fetch is not yet present in @types/node
+      "fetch",
+      (input: RequestInfo, init: RequestInit): Promise<Response> => {
+        if (init.method === "GET") {
+          t.assert(input === sampleOutputArtifactUrl);
+          t.deepEqual(init.headers, {
+            Authorization: `Bearer ${testJwt}`,
+          });
+
+          return Promise.resolve({
+            ok: true,
+            text: async () => Promise.resolve("unused"),
+            json: async () => Promise.resolve(sampleEDIAsJSON),
+          } as Response);
+        }
+
+        t.assert(
+          init.body === JSON.stringify(customMappingOutput),
+          "JSON payload was delivered to webhook",
+        );
+        t.deepEqual(init.headers, {
+          "Content-Type": "application/json",
+          ...authHeaderIfEnvVarSet(),
+        });
+        return Promise.resolve({
+          ok: true,
+          statusText: "created",
+          status: 201,
+          text: async () => Promise.resolve("result"),
+        } as Response);
+      },
+    );
+
+    const result = await handler(event);
+
+    const { calls } =
+      (
+        // @ts-expect-error fetch is not yet present in @types/node
+        fetch as {
+          mock: { calls: { arguments: string | { method: string }[] }[] };
+        }
+      ).mock;
+    t.assert(
+      calls.length === 2,
+      "two fetch calls are made (one to retrieve artifact, one to post JSON payload to webhook)",
+    );
+    t.assert(
+      calls[0]?.arguments?.[0] === sampleOutputArtifactUrl,
+      "first fetch call retrieves output artifact",
+    );
+    t.assert(
+      calls[1]?.arguments?.[0] === "test-webhook",
+      "second fetch call posts to webhook",
+    );
+
+    const invokeMappingCalls = mappings.commandCalls(MapDocumentCommand);
+    t.assert(invokeMappingCalls.length === 1);
+
+    t.deepEqual(result, {
+      statusText: "created",
+      statusCode: 201,
+      responseText: "result",
+    });
+  },
+);
+
+test.serial(
+  "thrown error includes mapping validation errors when strict mapping validation fails",
+  async (t) => {
+    tokens.on(GetTokenForIAMCommand, {}).resolvesOnce({
+      id_token: testJwt,
+    });
+
+    stash
+      .on(GetValueCommand, {
+        keyspaceName: "destinations-configuration",
+        key: `inbound|${sampleTransactionSetIdentifier}|${samplePartnershipId}`,
+      })
+      .resolvesOnce({
+        value: {
+          webhookUrl: "test-webhook",
+          mappingId: "test-mapping",
+          mappingValidation: "strict",
+        },
+      });
+
+    const mappingException = {
+      code: "validation_failed",
+      message:
+        "Strict mapping validation failed: The output of the mapping does not conform to the specified target JSON Schema.",
+      validationErrors: {
+        source: {
+          errors: [
+            {
+              code: "type",
+              jsonPointer: "/heading/test",
+              jsonSchemaPointer: "#/properties/heading/properties/test/type",
+              message: "must be number",
+            },
+          ],
+          mappingInput: { transactionSets: [sampleEDIAsJSON] },
+        },
+        target: undefined,
+      },
+      $metadata: {},
+    };
+
+    mappings
+      .on(MapDocumentCommand, {
+        id: "test-mapping",
+        content: {
+          transactionSets: [sampleEDIAsJSON],
+        },
+        validationMode: "strict",
+      })
+      .rejectsOnce(new MappingFailedException(mappingException));
+
+    mock.method(
+      global,
+      // @ts-expect-error fetch is not yet present in @types/node
+      "fetch",
+      (input: RequestInfo, init: RequestInit): Promise<Response> => {
+        t.assert(input === sampleOutputArtifactUrl);
+        t.deepEqual(init.headers, {
+          Authorization: `Bearer ${testJwt}`,
+        });
+
+        return Promise.resolve({
+          ok: true,
+          text: async () => Promise.resolve("unused"),
+          json: async () => Promise.resolve(sampleEDIAsJSON),
+        } as Response);
+      },
+    );
+
+    const error = await t.throwsAsync(handler(event));
+
+    const expectedErrorMessagePrefix = "Strict mapping validation failed:";
+    const expectedErrorMessage = `${expectedErrorMessagePrefix} ${
+      mappingException.message
+    } Validation errors: ${JSON.stringify(mappingException.validationErrors)}`;
+    t.assert(error?.message === expectedErrorMessage);
+
+    const { calls } =
+      (
+        // @ts-expect-error fetch is not yet present in @types/node
+        fetch as {
+          mock: { calls: { arguments: string | { method: string }[] }[] };
+        }
+      ).mock;
+    t.assert(
+      calls.length === 1,
+      "one fetch call is made (to retrieve artifact)",
+    );
+    t.assert(
+      calls[0]?.arguments?.[0] === sampleOutputArtifactUrl,
+      "fetch call retrieves output artifact",
+    );
+
+    const invokeMappingCalls = mappings.commandCalls(MapDocumentCommand);
+    t.assert(invokeMappingCalls.length === 1);
+  },
+);
+
+test.serial(
+  "thrown error includes stash schema validation errors when stash config entry is malformed",
+  async (t) => {
+    tokens.on(GetTokenForIAMCommand, {}).resolvesOnce({
+      id_token: testJwt,
+    });
+
+    stash
+      .on(GetValueCommand, {
+        keyspaceName: "destinations-configuration",
+        key: `inbound|${sampleTransactionSetIdentifier}|${samplePartnershipId}`,
+      })
+      .resolvesOnce({
+        value: {
+          webhookUrls: "test-webhook",
+        },
+      });
+
+    mock.method(
+      global,
+      // @ts-expect-error fetch is not yet present in @types/node
+      "fetch",
+      (input: RequestInfo, init: RequestInit): Promise<Response> => {
+        t.assert(input === sampleOutputArtifactUrl);
+        t.deepEqual(init.headers, {
+          Authorization: `Bearer ${testJwt}`,
+        });
+
+        return Promise.resolve({
+          ok: true,
+          text: async () => Promise.resolve("unused"),
+          json: async () => Promise.resolve(sampleEDIAsJSON),
+        } as Response);
+      },
+    );
+
+    const error = await t.throwsAsync(handler(event));
+
+    const expectedParsingErrors = [
+      {
+        code: "invalid_type",
+        expected: "string",
+        received: "undefined",
+        path: ["webhookUrl"],
+        message: "Required",
+      },
+      {
+        code: "unrecognized_keys",
+        keys: ["webhookUrls"],
+        path: [],
+        message: "Unrecognized key(s) in object: 'webhookUrls'",
+      },
+    ];
+    const expectedErrorPrefix = `Invalid stash configuration for inbound transaction: partnershipId=${samplePartnershipId}, transactionSet=${sampleTransactionSetIdentifier}.`;
+    const expectedErrorDetails = `Configuration parsing errors: ${JSON.stringify(expectedParsingErrors)}`;
+    const expectedErrorMessage = `${expectedErrorPrefix} ${expectedErrorDetails}`;
+    t.assert(error?.message === expectedErrorMessage);
+
+    const { calls } =
+      (
+        // @ts-expect-error fetch is not yet present in @types/node
+        fetch as {
+          mock: { calls: { arguments: string | { method: string }[] }[] };
+        }
+      ).mock;
+    t.assert(
+      calls.length === 1,
+      "one fetch call is made (to retrieve artifact)",
+    );
+    t.assert(
+      calls[0]?.arguments?.[0] === sampleOutputArtifactUrl,
+      "fetch call retrieves output artifact",
+    );
+
+    const invokeMappingCalls = mappings.commandCalls(MapDocumentCommand);
+    t.assert(invokeMappingCalls.length === 0);
+  },
+);
+
+test.serial(
+  "thrown error includes details about stash keyspace and keys to configure when lookup fails",
+  async (t) => {
+    tokens.on(GetTokenForIAMCommand, {}).resolvesOnce({
+      id_token: testJwt,
+    });
+
+    stash
+    .on(GetValueCommand, {
+      keyspaceName: "destinations-configuration",
+      key: `inbound|${sampleTransactionSetIdentifier}|${samplePartnershipId}`,
+    })
+    .resolvesOnce({ value: undefined })
+    .on(GetValueCommand, {
+      keyspaceName: "destinations-configuration",
+      key: `inbound|${sampleTransactionSetIdentifier}`,
+    })
+    .resolvesOnce({ value: undefined });
+
+    mock.method(
+      global,
+      // @ts-expect-error fetch is not yet present in @types/node
+      "fetch",
+      (input: RequestInfo, init: RequestInit): Promise<Response> => {
+        t.assert(input === sampleOutputArtifactUrl);
+        t.deepEqual(init.headers, {
+          Authorization: `Bearer ${testJwt}`,
+        });
+
+        return Promise.resolve({
+          ok: true,
+          text: async () => Promise.resolve("unused"),
+          json: async () => Promise.resolve(sampleEDIAsJSON),
+        } as Response);
+      },
+    );
+
+    const error = await t.throwsAsync(handler(event));
+
+    const partnershipScopedStashKey = `inbound|${sampleTransactionSetIdentifier}|${samplePartnershipId}`;
+    const transactionSetScopedStashKey = `inbound|${sampleTransactionSetIdentifier}`;
+    const expectedErrorPrefix = `No matching stash configuration found for inbound transaction: partnershipId=${samplePartnershipId}, transactionSet=${sampleTransactionSetIdentifier}.`;
+    const expectedErrorDetails = `Add destination config to 'destinations-configuration' stash keyspace using one of the following keys: '${partnershipScopedStashKey}' or '${transactionSetScopedStashKey}'`;
+    const expectedErrorMessage = `${expectedErrorPrefix} ${expectedErrorDetails}`;
+    t.assert(error?.message === expectedErrorMessage);
+
+    const { calls } =
+      (
+        // @ts-expect-error fetch is not yet present in @types/node
+        fetch as {
+          mock: { calls: { arguments: string | { method: string }[] }[] };
+        }
+      ).mock;
+    t.assert(
+      calls.length === 1,
+      "one fetch call is made (to retrieve artifact)",
+    );
+    t.assert(
+      calls[0]?.arguments?.[0] === sampleOutputArtifactUrl,
+      "fetch call retrieves output artifact",
+    );
+
+    const invokeMappingCalls = mappings.commandCalls(MapDocumentCommand);
+    t.assert(invokeMappingCalls.length === 0);
   },
 );

--- a/src/functions/multi-transaction-to-webhook/test/handler.unit.ts
+++ b/src/functions/multi-transaction-to-webhook/test/handler.unit.ts
@@ -1,0 +1,213 @@
+import test from "ava";
+import { handler } from "../handler.js";
+import {
+  mockClient,
+  samplePartnershipId,
+  sampleTransactionProcessedV2Event,
+  sampleTransactionSetIdentifier,
+  sampleOutputArtifactUrl,
+  testJwt,
+} from "@stedi/integrations-sdk/testing";
+import { mock } from "node:test";
+import { MapDocumentCommand, MappingsClient } from "@stedi/sdk-client-mappings";
+import { GetTokenForIAMCommand, TokensClient } from "@stedi/sdk-client-tokens";
+import { GetValueCommand, StashClient } from "@stedi/sdk-client-stash";
+
+const event = sampleTransactionProcessedV2Event();
+
+const sampleEDIAsJSON = { heading: { test: 1 } };
+const mappings = mockClient(MappingsClient);
+const stash = mockClient(StashClient);
+const tokens = mockClient(TokensClient);
+
+test.afterEach.always(() => {
+  mappings.reset();
+  mock.reset();
+  stash.reset();
+  tokens.reset();
+});
+
+const authHeaderIfEnvVarSet = () =>
+  process.env.AUTHORIZATION ? { Authorization: process.env.AUTHORIZATION } : {};
+
+test.serial("delivers EDI as guide JSON to webhook url", async (t) => {
+  tokens.on(GetTokenForIAMCommand, {}).resolvesOnce({
+    id_token: testJwt,
+  });
+
+  stash
+    .on(GetValueCommand, {
+      keyspaceName: "destinations-configuration",
+      key: `inbound|${sampleTransactionSetIdentifier}|${samplePartnershipId}`,
+    })
+    .resolvesOnce({
+      value: {
+        webhookUrl: "test-webhook",
+      },
+    });
+
+  mock.method(
+    global,
+    // @ts-expect-error fetch is not yet present in @types/node
+    "fetch",
+    (input: RequestInfo, init: RequestInit): Promise<Response> => {
+      if (init.method === "GET") {
+        t.assert(input === sampleOutputArtifactUrl);
+        t.deepEqual(init.headers, {
+          Authorization: `Bearer ${testJwt}`,
+        });
+
+        return Promise.resolve({
+          ok: true,
+          text: async () => Promise.resolve("unused"),
+          json: async () => Promise.resolve(sampleEDIAsJSON),
+        } as Response);
+      }
+
+      t.assert(
+        init.body === JSON.stringify(sampleEDIAsJSON),
+        "JSON payload was delivered to webhook",
+      );
+      t.deepEqual(init.headers, {
+        "Content-Type": "application/json",
+        ...authHeaderIfEnvVarSet(),
+      });
+      return Promise.resolve({
+        ok: true,
+        statusText: "created",
+        status: 201,
+        text: async () => Promise.resolve("result"),
+      } as Response);
+    },
+  );
+
+  const result = await handler(event);
+
+  const { calls } =
+  (
+    // @ts-expect-error fetch is not yet present in @types/node
+    fetch as {
+      mock: { calls: { arguments: string | { method: string }[] }[] };
+    }
+  ).mock;
+  t.assert(
+    calls.length === 2,
+    "two fetch calls are made (one to retrieve artifact, one to post JSON payload to webhook)",
+  );
+  t.assert(
+    calls[0]?.arguments?.[0] === sampleOutputArtifactUrl,
+    "first fetch call retrieves output artifact",
+  );
+  t.assert(
+    calls[1]?.arguments?.[0] === "test-webhook",
+    "second fetch call posts to webhook",
+  );
+
+  const invokeMappingCalls = mappings.commandCalls(MapDocumentCommand);
+  t.assert(invokeMappingCalls.length === 0);
+
+  t.deepEqual(result, {
+    statusText: "created",
+    statusCode: 201,
+    responseText: "result",
+  });
+});
+
+test.serial(
+  "delivers EDI as transformed JSON to webhook url when mappingId is configured",
+  async (t) => {
+    tokens.on(GetTokenForIAMCommand, {}).resolvesOnce({
+      id_token: testJwt,
+    });
+
+    stash
+      .on(GetValueCommand, {
+        keyspaceName: "destinations-configuration",
+        key: `inbound|${sampleTransactionSetIdentifier}|${samplePartnershipId}`,
+      })
+      .resolvesOnce({
+        value: {
+          webhookUrl: "test-webhook",
+          mappingId: "test-mapping",
+          mapAsGuideJson: false,
+        },
+      });
+
+    const customMappingOutput = {
+      custom: "payload",
+    };
+
+    mappings.on(MapDocumentCommand, {
+      id: "test-mapping",
+      content: sampleEDIAsJSON,
+    }).resolvesOnce({
+      content: customMappingOutput,
+    });
+
+    mock.method(
+      global,
+      // @ts-expect-error fetch is not yet present in @types/node
+      "fetch",
+      (input: RequestInfo, init: RequestInit): Promise<Response> => {
+        if (init.method === "GET") {
+          t.assert(input === sampleOutputArtifactUrl);
+          t.deepEqual(init.headers, {
+            Authorization: `Bearer ${testJwt}`,
+          });
+
+          return Promise.resolve({
+            ok: true,
+            text: async () => Promise.resolve("unused"),
+            json: async () => Promise.resolve(sampleEDIAsJSON),
+          } as Response);
+        }
+
+        t.assert(
+          init.body === JSON.stringify(customMappingOutput),
+          "JSON payload was delivered to webhook",
+        );
+        t.deepEqual(init.headers, {
+          "Content-Type": "application/json",
+          ...authHeaderIfEnvVarSet(),
+        });
+        return Promise.resolve({
+          ok: true,
+          statusText: "created",
+          status: 201,
+          text: async () => Promise.resolve("result"),
+        } as Response);
+      },
+    );
+
+    const result = await handler(event);
+
+    const { calls } =
+      (
+        // @ts-expect-error fetch is not yet present in @types/node
+        fetch as {
+          mock: { calls: { arguments: string | { method: string }[] }[] };
+        }
+      ).mock;
+    t.assert(
+      calls.length === 2,
+      "two fetch calls are made (one to retrieve artifact, one to post JSON payload to webhook)",
+    );
+    t.assert(
+      calls[0]?.arguments?.[0] === sampleOutputArtifactUrl,
+      "first fetch call retrieves output artifact",
+    );
+    t.assert(
+      calls[1]?.arguments?.[0] === "test-webhook",
+      "second fetch call posts to webhook",
+    );
+
+    const invokeMappingCalls = mappings.commandCalls(MapDocumentCommand);
+    t.assert(invokeMappingCalls.length === 1);
+
+    t.deepEqual(result, {
+      statusText: "created",
+      statusCode: 201,
+      responseText: "result",
+    });
+  },
+);

--- a/src/functions/transaction-to-webhook/test/handler.unit.ts
+++ b/src/functions/transaction-to-webhook/test/handler.unit.ts
@@ -15,7 +15,7 @@ const sampleEDIAsJSON = { heading: { test: 1 } };
 const buckets = mockClient(BucketsClient);
 const mappings = mockClient(MappingsClient);
 
-test.afterEach(() => {
+test.afterEach.always(() => {
   buckets.reset();
   mappings.reset();
   mock.reset();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "lib": ["es2022"],
-    "module": "esnext" /* Specify what module code is generated. */,
+    "module": "nodenext" /* Specify what module code is generated. */,
     "moduleResolution": "nodenext" /* Specify how TypeScript looks up a file from a given module specifier. */,
 
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,


### PR DESCRIPTION
Implementation for a "multi-transaction-to-webhook" function template that uses Stash to look up destination configuration details. README to follow in a subsequent PR:

keyspace name: `destinations-configuration`

destination key conventions (lookups performed in this order):
- `inbound|${transactionSetId}|${partnershipId}`
- `inbound|${transactionSetId}`

value schema: 
```typescript
  {
    webhookUrl: string,
    authorization?: string,
    mappingId?: string,
    mapAsGuideJson?: boolean,  // default true, wraps transaction in `transactionSets` array
    mappingValidation?: "strict",
  }
```
